### PR TITLE
Support ASN_COUNTER64

### DIFF
--- a/gkrellm_snmp.c
+++ b/gkrellm_snmp.c
@@ -449,6 +449,7 @@ snmp_input(int op,
 		    break;
 		case ASN_INTEGER: /* value is a integer */
 		case ASN_COUNTER: /* use as if it were integer */
+		case ASN_COUNTER64: /* use as if it were integer */
 		case ASN_UNSIGNED: /* use as if it were integer */
 		    asn1_type = ASN_INTEGER;
 		    result_n = *vars->val.integer;


### PR DESCRIPTION
SNMP has added a new type, ASN_COUNTER64, for 64-bit integers.  This commit adds support for that type.